### PR TITLE
fixing react-navigation import

### DIFF
--- a/code/appWithAsync.js
+++ b/code/appWithAsync.js
@@ -4,7 +4,7 @@ import {
   Button, TextInput, ActivityIndicator
 } from 'react-native';
 import { Constants} from "expo";
-import { StackNavigator } from 'react-navigation';
+import { createStackNavigator, createAppContainer }  from 'react-navigation';
 
 const Touchable = (props) => (
   <TouchableOpacity style={styles.button} onPress={props.onPress}>
@@ -61,11 +61,11 @@ export default App = () => (
   </View>
 )
 
-const RouteStack = StackNavigator({
+const RouteStack = createAppContainer(createStackNavigator({
   Home: { screen: HomeScreen },
   randomperson: { screen: RandomPerson },
   fetchperson: { screen: FetchPerson },
-});
+}));
 
 const styles = StyleSheet.create({
   button: {


### PR DESCRIPTION
Current version gives following error:
(0,p.StackNavigator) is not a function. (In '(0,p.StackNavigator)({Home:{screen:b},randomperson:{screen:y},fetchperson:{screen:E}})', '(0,p.StackNavigator)' is undefined)

- This will fix it.